### PR TITLE
Update configuration and script path(s) in the P21Play database.

### DIFF
--- a/Administration/p21_play_database_setup.sql
+++ b/Administration/p21_play_database_setup.sql
@@ -30,38 +30,6 @@ ALTER DATABASE [P21Play] SET TRUSTWORTHY ON;
 --Positively set the owner of the DB, modify as you see fit
 ALTER AUTHORIZATION ON DATABASE::P21Play TO sa;
 
--- Set all configuration options needed for P21
--- -- Allow for advanced options to be configured
-EXEC sp_configure 'show advanced options', 1;
-GO
-RECONFIGURE;
-GO
--- -- Enable SQL Server Agent extended stored procedures.
-EXEC sp_configure 'Agent XPs', 1;
-GO
-RECONFIGURE
-GO
--- -- Enable OLE Automation procedures.
-EXEC sp_configure 'Ole Automation Procedures', 1;
-GO
-RECONFIGURE;
-GO
--- -- Enable the command shell extended stored procedure.
-EXEC sp_configure 'xp_cmdshell', 1;
-GO
-RECONFIGURE;
-GO
--- -- Enable CLR integration.
-EXEC sp_configure 'clr enabled' , '1';
-GO
-RECONFIGURE;
-GO
--- -- Enable Database Mail extended stored procedures.
-EXEC sp_configure 'Database Mail XPs', 1;
-GO
-RECONFIGURE
-GO
-
 -- Append Company names with P21Play
 UPDATE [P21Play].dbo.company SET 
 	company_name = LEFT(company_name, 20) + ' (P21Play)';

--- a/Administration/p21_play_database_setup.sql
+++ b/Administration/p21_play_database_setup.sql
@@ -9,6 +9,7 @@ DECLARE @backupFile VARCHAR(80) = 'S:\YourBackupFileNameHere.bak'
 DECLARE @playRulesLocation VARCHAR(80) = 'C:\Program Files (x86)\Activant\DynaChangeRulesPlay'
 DECLARE @playCrystalPath VARCHAR(80) = 'C:\Reports_P21Play'
 DECLARE @liveCrystalPath VARCHAR(80) = 'C:\P21_Reports'
+DECLARE @playScriptPath VARCHAR(80) = 'C:\P21Forms_P21Play'
 
 --Assumes that you have an existing Play database, comment this out
 --if you don't.  
@@ -57,6 +58,19 @@ UPDATE [P21Play].dbo.label_definition_x_loc SET
 --Change Crystal External Reports
 UPDATE [P21Play].dbo.[crystal_external_report] SET 
 	report_path = @playCrystalPath;
+
+-- Update System script path
+-- Avoids unintended document "merging" in production-generated forms
+UPDATE [P21Play].dbo.system_setting 
+SET [value] = @playScriptPath
+WHERE [name] = 'script_path';
+
+-- Update User script paths (if set) to a subfolder of the system script path, i.e.:
+--    C:\P21Forms_P21Play\John.Public
+-- Avoids unintended document "merging" in production-generated forms
+UPDATE [P21Play].dbo.users
+SET script_path = @playScriptPath + '\' + [P21Play].dbo.users.id
+WHERE DATALENGTH( [P21Play].dbo.users.script_path ) > 0
 
 --Shut off all alerts & Rebuild Alert system
 UPDATE [P21Play].dbo.alert_implementation SET 

--- a/Administration/p21_play_database_setup.sql
+++ b/Administration/p21_play_database_setup.sql
@@ -30,6 +30,38 @@ ALTER DATABASE [P21Play] SET TRUSTWORTHY ON;
 --Positively set the owner of the DB, modify as you see fit
 ALTER AUTHORIZATION ON DATABASE::P21Play TO sa;
 
+-- Set all configuration options needed for P21
+-- -- Allow for advanced options to be configured
+EXEC sp_configure 'show advanced options', 1;
+GO
+RECONFIGURE;
+GO
+-- -- Enable SQL Server Agent extended stored procedures.
+EXEC sp_configure 'Agent XPs', 1;
+GO
+RECONFIGURE
+GO
+-- -- Enable OLE Automation procedures.
+EXEC sp_configure 'Ole Automation Procedures', 1;
+GO
+RECONFIGURE;
+GO
+-- -- Enable the command shell extended stored procedure.
+EXEC sp_configure 'xp_cmdshell', 1;
+GO
+RECONFIGURE;
+GO
+-- -- Enable CLR integration.
+EXEC sp_configure 'clr enabled' , '1';
+GO
+RECONFIGURE;
+GO
+-- -- Enable Database Mail extended stored procedures.
+EXEC sp_configure 'Database Mail XPs', 1;
+GO
+RECONFIGURE
+GO
+
 -- Append Company names with P21Play
 UPDATE [P21Play].dbo.company SET 
 	company_name = LEFT(company_name, 20) + ' (P21Play)';


### PR DESCRIPTION
Couple of commits for the play db restore/setup script.
- Update to system and user script paths to avoid potential problems in *production*
- Setting of configuration options in the case that the restore/setup is being done on a new server/instance